### PR TITLE
Remove goreq completely from device_extra.go

### DIFF
--- a/asyncwriter_test.go
+++ b/asyncwriter_test.go
@@ -30,5 +30,5 @@ Loop:
 			break Loop
 		}
 	}
-	log.Printf("copy error:", sync.Err())
+	log.Printf("copy error: %s", sync.Err())
 }

--- a/device_extra.go
+++ b/device_extra.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/franela/goreq"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
@@ -220,11 +219,6 @@ func (c *Device) DoSyncLocalFile(dst string, src string, perms os.FileMode) (aw 
 func (c *Device) DoSyncHTTPFile(dst string, srcUrl string, perms os.FileMode) (aw *AsyncWriter, err error) {
 	res, err := retryablehttp.Get(srcUrl)
 
-	// res, err := goreq.Request{
-	// 	Uri:             srcUrl,
-	// 	RedirectHeaders: true,
-	// 	MaxRedirects:    10,
-	// }.Do()
 	if err != nil {
 		return
 	}
@@ -272,18 +266,14 @@ func (c *Device) WriteToFile(path string, rd io.Reader, perms os.FileMode) (writ
 
 // WriteHttpToFile download http resource to device
 func (c *Device) WriteHttpToFile(path string, urlStr string, perms os.FileMode) (written int64, err error) {
-	resp, err := goreq.Request{
-		Uri:             urlStr,
-		RedirectHeaders: true,
-		MaxRedirects:    10,
-	}.Do()
+	res, err := retryablehttp.Get(urlStr)
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("http download <%s> status %v", urlStr, resp.Status)
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		err = fmt.Errorf("http download <%s> status %v", urlStr, res.Status)
 		return
 	}
-	return c.WriteToFile(path, resp.Body, perms)
+	return c.WriteToFile(path, res.Body, perms)
 }

--- a/device_watcher_test.go
+++ b/device_watcher_test.go
@@ -3,9 +3,9 @@ package adb
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/yosemite-open/go-adb/internal/errors"
 	"github.com/yosemite-open/go-adb/wire"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestParseDeviceStatesSingle(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/yosemite-open/go-adb/wire"
 	"github.com/stretchr/testify/assert"
+	"github.com/yosemite-open/go-adb/wire"
 )
 
 func TestNewServer_ZeroConfig(t *testing.T) {

--- a/sync_client_test.go
+++ b/sync_client_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yosemite-open/go-adb/internal/errors"
-	"github.com/yosemite-open/go-adb/wire"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/yosemite-open/go-adb/internal/errors"
+	"github.com/yosemite-open/go-adb/wire"
 )
 
 var someTime = time.Date(2015, 5, 3, 8, 8, 8, 0, time.UTC)

--- a/sync_file_reader_test.go
+++ b/sync_file_reader_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yosemite-open/go-adb/wire"
 	"github.com/stretchr/testify/assert"
+	"github.com/yosemite-open/go-adb/wire"
 )
 
 func TestReadNextChunk(t *testing.T) {

--- a/sync_file_writer_test.go
+++ b/sync_file_writer_test.go
@@ -8,8 +8,8 @@ import (
 	"encoding/binary"
 	"strings"
 
-	"github.com/yosemite-open/go-adb/wire"
 	"github.com/stretchr/testify/assert"
+	"github.com/yosemite-open/go-adb/wire"
 )
 
 func TestFileWriterWriteSingleChunk(t *testing.T) {

--- a/wire/scanner_test.go
+++ b/wire/scanner_test.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/yosemite-open/go-adb/internal/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/yosemite-open/go-adb/internal/errors"
 )
 
 func TestReadStatusOkay(t *testing.T) {

--- a/wire/sync_test.go
+++ b/wire/sync_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yosemite-open/go-adb/internal/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/yosemite-open/go-adb/internal/errors"
 )
 
 var (

--- a/wire/util_test.go
+++ b/wire/util_test.go
@@ -3,8 +3,8 @@ package wire
 import (
 	"testing"
 
-	"github.com/yosemite-open/go-adb/internal/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/yosemite-open/go-adb/internal/errors"
 )
 
 func TestAdbServerError_NoRequest(t *testing.T) {


### PR DESCRIPTION
Use retryablehttp for the WriteHttpToFile method.

I also ran gofmt on all files and fixed an error in asyncwriter_test.go.

go build and go test still pass.